### PR TITLE
Features/search async improvements

### DIFF
--- a/src/Denrage.AchievementTrackerModule/Interfaces/IAchievementItemOverviewFactory.cs
+++ b/src/Denrage.AchievementTrackerModule/Interfaces/IAchievementItemOverviewFactory.cs
@@ -1,4 +1,5 @@
 ﻿using Denrage.AchievementTrackerModule.Libs.Achievement;
+using Denrage.AchievementTrackerModule.Models;
 using Denrage.AchievementTrackerModule.UserInterface.Views;
 using Gw2Sharp.WebApi.V2.Models;
 using System.Collections.Generic;
@@ -7,6 +8,6 @@ namespace Denrage.AchievementTrackerModule.Interfaces
 {
     public interface IAchievementItemOverviewFactory
     {
-        AchievementItemOverview Create(IEnumerable<(AchievementCategory, AchievementTableEntry)> achievements, string title);
+        AchievementItemOverview Create(IEnumerable<CategoryAchievements> achievements, string title);
     }
 }

--- a/src/Denrage.AchievementTrackerModule/Models/CategoryAchievements.cs
+++ b/src/Denrage.AchievementTrackerModule/Models/CategoryAchievements.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Denrage.AchievementTrackerModule.Libs.Achievement;
+using Gw2Sharp.WebApi.V2.Models;
+
+namespace Denrage.AchievementTrackerModule.Models
+{
+    public class CategoryAchievements
+    {
+        public CategoryAchievements(AchievementCategory category, AchievementTableEntry achievement)
+        {
+            this.Category = category;
+            this.Achievement = achievement;
+        }
+
+        public AchievementCategory Category { get; set; }
+        public AchievementTableEntry Achievement { get; set; }
+
+    }
+}

--- a/src/Denrage.AchievementTrackerModule/Module.cs
+++ b/src/Denrage.AchievementTrackerModule/Module.cs
@@ -1,4 +1,4 @@
-﻿using Blish_HUD;
+using Blish_HUD;
 using Blish_HUD.Controls;
 using Blish_HUD.Graphics.UI;
 using Blish_HUD.Modules;
@@ -65,49 +65,39 @@ namespace Denrage.AchievementTrackerModule
 
         protected override async Task LoadAsync()
         {
-            _ = Task.Run(async () =>
-            {
-
                 this.achievementOverviewView = () => new AchievementTrackerView(
                         this.dependencyInjectionContainer.AchievementItemOverviewFactory,
                         this.dependencyInjectionContainer.AchievementService);
 
-                await Task.Delay(TimeSpan.FromSeconds(3));
-                await this.dependencyInjectionContainer.InitializeAsync(this.autoSave, this.limitAchievements);
-                this.dependencyInjectionContainer.AchievementTrackerService.AchievementTracked += this.AchievementTrackerService_AchievementTracked;
+            if (this.dependencyInjectionContainer.PersistanceService.Get().ShowTrackWindow)
+            {
+                this.InitializeWindow();
+                this.window.Show();
+            }
 
-                if (this.dependencyInjectionContainer.PersistanceService.Get().ShowTrackWindow)
-                {
-                    this.InitializeWindow();
-                    this.window.Show();
-                }
+            this.blishhudOverlayTab = GameService.Overlay.BlishHudWindow.AddTab(
+                "Achievement Tracker",
+                this.ContentsManager.GetTexture("achievement_icon.png"),
+                this.achievementOverviewView);
 
-                this.blishhudOverlayTab = GameService.Overlay.BlishHudWindow.AddTab(
-                    "Achievement Tracker",
-                    this.ContentsManager.GetTexture("achievement_icon.png"),
-                    this.achievementOverviewView);
+            this.cornerIcon = new CornerIcon()
+            {
+                // TODO: Localize
+                IconName = "Open Achievement Panel",
+                Icon = this.ContentsManager.GetTexture(@"corner_icon_inactive.png"),
+                HoverIcon = this.ContentsManager.GetTexture(@"corner_icon_active.png"),
+                Width = 64,
+                Height = 64,
+            };
 
-                this.cornerIcon = new CornerIcon()
-                {
-                    // TODO: Localize
-                    IconName = "Open Achievement Panel",
-                    Icon = this.ContentsManager.GetTexture(@"corner_icon_inactive.png"),
-                    HoverIcon = this.ContentsManager.GetTexture(@"corner_icon_active.png"),
-                    Width = 64,
-                    Height = 64,
-                };
+            this.cornerIcon.Click += (s, e) =>
+            {
+                this.InitializeWindow();
 
-                this.cornerIcon.Click += (s, e) =>
-                {
-                    this.InitializeWindow();
+                this.window.ToggleWindow();
+            };
 
-                    this.window.ToggleWindow();
-                };
-
-                this.dependencyInjectionContainer.PersistanceService.AutoSave += this.SavePersistentInformation;
-            });
-
-            await base.LoadAsync();
+            this.dependencyInjectionContainer.PersistanceService.AutoSave += this.SavePersistentInformation;
         }
 
         private void InitializeWindow()

--- a/src/Denrage.AchievementTrackerModule/Module.cs
+++ b/src/Denrage.AchievementTrackerModule/Module.cs
@@ -65,9 +65,12 @@ namespace Denrage.AchievementTrackerModule
 
         protected override async Task LoadAsync()
         {
-                this.achievementOverviewView = () => new AchievementTrackerView(
-                        this.dependencyInjectionContainer.AchievementItemOverviewFactory,
-                        this.dependencyInjectionContainer.AchievementService);
+            this.achievementOverviewView = () => new AchievementTrackerView(
+                    this.dependencyInjectionContainer.AchievementItemOverviewFactory,
+                    this.dependencyInjectionContainer.AchievementService);
+
+            await this.dependencyInjectionContainer.InitializeAsync(this.autoSave, this.limitAchievements);
+            this.dependencyInjectionContainer.AchievementTrackerService.AchievementTracked += this.AchievementTrackerService_AchievementTracked;
 
             if (this.dependencyInjectionContainer.PersistanceService.Get().ShowTrackWindow)
             {

--- a/src/Denrage.AchievementTrackerModule/Services/Factories/AchievementItemOverviewFactory.cs
+++ b/src/Denrage.AchievementTrackerModule/Services/Factories/AchievementItemOverviewFactory.cs
@@ -1,5 +1,6 @@
 ﻿using Denrage.AchievementTrackerModule.Interfaces;
 using Denrage.AchievementTrackerModule.Libs.Achievement;
+using Denrage.AchievementTrackerModule.Models;
 using Denrage.AchievementTrackerModule.UserInterface.Views;
 using Gw2Sharp.WebApi.V2.Models;
 using System.Collections.Generic;
@@ -17,7 +18,7 @@ namespace Denrage.AchievementTrackerModule.Services.Factories
             this.achievementService = achievementService;
         }
 
-        public AchievementItemOverview Create(IEnumerable<(AchievementCategory, AchievementTableEntry)> achievements, string title)
+        public AchievementItemOverview Create(IEnumerable<CategoryAchievements> achievements, string title)
             => new AchievementItemOverview(achievements, title, this.achievementService, this.achievementListItemFactory);
     }
 }

--- a/src/Denrage.AchievementTrackerModule/UserInterface/Views/AchievementItemOverview.cs
+++ b/src/Denrage.AchievementTrackerModule/UserInterface/Views/AchievementItemOverview.cs
@@ -2,6 +2,7 @@
 using Blish_HUD.Graphics.UI;
 using Denrage.AchievementTrackerModule.Interfaces;
 using Denrage.AchievementTrackerModule.Libs.Achievement;
+using Denrage.AchievementTrackerModule.Models;
 using Gw2Sharp.WebApi.V2.Models;
 using Microsoft.Xna.Framework;
 using System.Collections.Generic;
@@ -12,12 +13,12 @@ namespace Denrage.AchievementTrackerModule.UserInterface.Views
     public class AchievementItemOverview : View
     {
         private readonly IAchievementService achievementService;
-        private readonly IEnumerable<(AchievementCategory Category, AchievementTableEntry Achievement)> achievements;
+        private readonly IEnumerable<CategoryAchievements> achievements;
         private readonly IAchievementListItemFactory achievementListItemFactory;
         private readonly string title;
 
         public AchievementItemOverview(
-            IEnumerable<(AchievementCategory, AchievementTableEntry)> achievements,
+            IEnumerable<CategoryAchievements> achievements,
             string title,
             IAchievementService achievementService,
             IAchievementListItemFactory achievementListItemFactory)


### PR DESCRIPTION
There was an issue with the search feature. Typing in the search box would cast skills and open in-game UI panels. It seemed to be caused by the search running in separate threads (async).

I've rebuilt the search and made it a lot simpler. It's still not the same as how other modules do it, because they use one flow panel and simply filter all the children inside. We may need to look into this at some point to make the rendering smoother (currently the search has a flicker).
